### PR TITLE
Исправление мультиязычной генерации sitemap через CLI

### DIFF
--- a/com_jlsitemap/admin/src/Service/SitemapRuntimeContextFactory.php
+++ b/com_jlsitemap/admin/src/Service/SitemapRuntimeContextFactory.php
@@ -13,16 +13,27 @@ namespace Joomla\Component\JLSitemap\Administrator\Service;
 \defined('_JEXEC') or die;
 
 use Joomla\CMS\Access\Access;
+use Joomla\CMS\Application\SiteApplication;
 use Joomla\CMS\Component\ComponentHelper;
+use Joomla\CMS\Event\Application\AfterInitialiseEvent;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Multilanguage;
+use Joomla\CMS\Plugin\PluginHelper;
+use Joomla\CMS\Router\SiteRouter;
 use Joomla\CMS\Uri\Uri;
+use Throwable;
 
 class SitemapRuntimeContextFactory
 {
+    protected static bool $siteRoutingContextPrepared = false;
+
     public function create(): array
     {
-        $siteConfig = Factory::getContainer()->get('config');
+        $siteConfig       = Factory::getContainer()->get('config');
+        $multilanguage    = Multilanguage::isEnabled();
+        $defaultLanguage  = ComponentHelper::getParams('com_languages')->get('site', 'en-GB');
+
+        $this->prepareSiteRoutingContext($multilanguage, $defaultLanguage);
 
         return [
             'siteSef'         => ($siteConfig->get('sef') == 1),
@@ -30,8 +41,8 @@ class SitemapRuntimeContextFactory
             'siteRobots'      => $siteConfig->get('robots'),
             'siteRoot'        => $this->resolveSiteRoot(),
             'guestAccess'     => $this->getGuestAccessLevels(),
-            'multilanguage'   => Multilanguage::isEnabled(),
-            'defaultLanguage' => ComponentHelper::getParams('com_languages')->get('site', 'en-GB'),
+            'multilanguage'   => $multilanguage,
+            'defaultLanguage' => $defaultLanguage,
         ];
     }
 
@@ -43,5 +54,56 @@ class SitemapRuntimeContextFactory
     protected function resolveSiteRoot(): string
     {
         return Uri::getInstance()->toString(['scheme', 'host', 'port']);
+    }
+
+    protected function prepareSiteRoutingContext(bool $multilanguage, string $defaultLanguage): void
+    {
+        if (!$multilanguage || self::$siteRoutingContextPrepared) {
+            return;
+        }
+
+        $languageFilterEnabled = PluginHelper::isEnabled('system', 'languagefilter');
+
+        if (!$languageFilterEnabled) {
+            self::$siteRoutingContextPrepared = true;
+
+            return;
+        }
+
+        try {
+            $container = Factory::getContainer();
+            $siteApp   = $container->get(SiteApplication::class);
+            $siteApp->setLanguageFilter(true);
+            $siteApp->set('language', $defaultLanguage);
+
+            if (!$this->hasLanguageFilterBuildRule($container->get(SiteRouter::class))) {
+                $languageFilter = Factory::getApplication()->bootPlugin('languagefilter', 'system');
+
+                if (method_exists($languageFilter, 'onAfterInitialise')) {
+                    $languageFilter->onAfterInitialise(
+                        new AfterInitialiseEvent('onAfterInitialise', ['subject' => $siteApp])
+                    );
+                }
+            }
+        } catch (Throwable) {
+            return;
+        }
+
+        self::$siteRoutingContextPrepared = true;
+    }
+
+    protected function hasLanguageFilterBuildRule(SiteRouter $router): bool
+    {
+        foreach ($router->getRules()['buildpreprocess'] ?? [] as $rule) {
+            if (!is_array($rule) || ($rule[1] ?? null) !== 'preprocessBuildRule' || !is_object($rule[0] ?? null)) {
+                continue;
+            }
+
+            if (str_contains(get_class($rule[0]), '\\Plugin\\System\\LanguageFilter\\')) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/plg_jlsitemap_content/src/Extension/Content.php
+++ b/plg_jlsitemap_content/src/Extension/Content.php
@@ -203,7 +203,9 @@ final class Content extends CMSPlugin implements SubscriberInterface
             // Add alternates to categories
             if (!empty($alternates)) {
                 foreach ($categories as &$category) {
-                    $category->alternates = ($category->alternates) ? $alternates[$category->alternates] : false;
+                    $category->alternates = ($category->alternates && isset($alternates[$category->alternates]))
+                        ? $alternates[$category->alternates]
+                        : false;
                 }
             }
 
@@ -291,7 +293,7 @@ final class Content extends CMSPlugin implements SubscriberInterface
 
                 $publishUp = $row->publish_up ?? null;
 
-                if (empty($publishUp) || $publishUp == $nullDate || Factory::getDate($publishUp)->toUnix() > $nowDate) {
+                if (!empty($publishUp) && $publishUp != $nullDate && Factory::getDate($publishUp)->toUnix() > $nowDate) {
                     $exclude[] = [
                         'type' => Text::_('PLG_JLSITEMAP_CONTENT_EXCLUDE_ARTICLE'),
                         'msg'  => Text::_('PLG_JLSITEMAP_CONTENT_EXCLUDE_ARTICLE_PUBLISH_UP'),
@@ -365,7 +367,9 @@ final class Content extends CMSPlugin implements SubscriberInterface
             // Add alternates to articles
             if (!empty($alternates)) {
                 foreach ($articles as &$article) {
-                    $article->alternates = ($article->alternates) ? $alternates[$article->alternates] : false;
+                    $article->alternates = ($article->alternates && isset($alternates[$article->alternates]))
+                        ? $alternates[$article->alternates]
+                        : false;
                 }
             }
 


### PR DESCRIPTION
## Что изменено

  - Исправлена генерация sitemap через Joomla Scheduler CLI на мультиязычных сайтах.
  - CLI теперь подготавливает site routing context без HTTP-запроса к фронтенду.
  - Для `SiteRouter` подключается состояние `SiteApplication` и правила `system/
  languagefilter`.
  - В content provider добавлены guard-проверки для неполных association groups.
  - Исправлена логика `publish_up`: пустое или Joomla null-date значение больше не
  исключает опубликованный материал из sitemap.

  ## Почему

  На мультиязычных сайтах Scheduler CLI мог генерировать некорректные URL: provider
  records сворачивались в главную или language-home URL вроде `/?lang=en-GB` / `/?
  lang=ru-RU`.

  Причина была не в выборе роутера: `Route::link('site', ...)` уже использовался.
  Проблема была в том, что CLI не выполняет site lifecycle, где обычно включается
  language filter state и подключаются build rules плагина `system/languagefilter`.

  ## Проверка

  - `php -l` для изменённых PHP-файлов.
  - Сборка пакета: `_dist/pkg_jlsitemap_v2.2.0_j5_j6.zip`.
  - Установка пакета на локальный Joomla 6.1 stand.
  - Настроен мультиязычный `joomla.local`: `en-GB`, `ru-RU`, language filter, language
  switcher, language-specific home/menu items.
  - Scheduler CLI:
    - task `5` выполнен успешно;
    - PHP warnings нет;
    - sitemap содержит `63` URL;
    - `/en/` URL: `27`;
    - `/ru/` URL: `35`;
    - `?lang=` home-collapse URL: `0`;
    - content и JoomShopping provider URLs присутствуют.
  - Проверено, что CLI generation не использует frontend HTTP loopback.